### PR TITLE
implement deep cleaning simulators

### DIFF
--- a/MacSpaceCleaner/Base/AppDelegate.swift
+++ b/MacSpaceCleaner/Base/AppDelegate.swift
@@ -98,6 +98,9 @@ private extension AppDelegate {
             NSMenuItem(title: "Clear Cocoa Pods Cache",       action: #selector(clearCocoaPodsCache),       keyEquivalent: "P"),
             NSMenuItem(title: "Empty Trash",                  action: #selector(emptyTrash),                keyEquivalent: "D"),
             NSMenuItem.separator(),
+            NSMenuItem(title: "Remove Simulator Previews", action: #selector(removeSimulatorPreviews), keyEquivalent: "O"),
+            NSMenuItem(title: "Remove Simulators Data", action: #selector(removeSimulatorsData), keyEquivalent: "L"),
+            NSMenuItem.separator(),
             NSMenuItem(title: "Clear All",                    action: #selector(clearAll),                  keyEquivalent: "E"),
             NSMenuItem.separator(),
             NSMenuItem(title: "About MSC",                    action: #selector(about),                     keyEquivalent: ""),
@@ -179,6 +182,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     func clearCaches()               { self.viewModel.perform(action: .clearCaches)               }
     func removeOldSimulators()       { self.viewModel.perform(action: .removeOldSimulators)       }
     func clearCocoaPodsCache()       { self.viewModel.perform(action: .clearCocoaPodsCache)       }
+    func removeSimulatorPreviews()   { self.viewModel.perform(action: .removeSimulatorPreviews)   }
+    func removeSimulatorsData()      { self.viewModel.perform(action: .removeSimulatorsData)      }
     func emptyTrash()                { self.viewModel.perform(action: .emptyTrash)                }
     func clearAll()                  { self.viewModel.clearAll()                                  }
     

--- a/MacSpaceCleaner/Base/AppViewModel.swift
+++ b/MacSpaceCleaner/Base/AppViewModel.swift
@@ -31,6 +31,8 @@ class AppViewModel {
         case clearTVOSDeviceSupport
         case clearCaches
         case removeOldSimulators
+        case removeSimulatorPreviews
+        case removeSimulatorsData
         case clearCocoaPodsCache
         case emptyTrash
     }
@@ -85,6 +87,20 @@ class AppViewModel {
             let successTitle = "Remove Old Simulators"
             let successMessage = "Old simulators removed successfully!"
             let failureMessage = "Failed to remove old simulators"
+            self.runShellCommand(launchPath: launchPath, arguments: arguments, successTitle: successTitle, successMessage: successMessage, failureMessage: failureMessage)
+        case .removeSimulatorPreviews:
+            let launchPath = "/usr/bin/xcrun"
+            let arguments = ["simctl", "--set", "previews", "delete", "all"]
+            let successTitle = "Remove Simulator Previews"
+            let successMessage = "Simulator Previews removed successfully!"
+            let failureMessage = "Failed to remove Simulator Previews"
+            self.runShellCommand(launchPath: launchPath, arguments: arguments, successTitle: successTitle, successMessage: successMessage, failureMessage: failureMessage)
+        case .removeSimulatorsData:
+            let launchPath = "/usr/bin/xcrun"
+            let arguments = ["simctl", "erase", "all"]
+            let successTitle = "Remove Simulators Data"
+            let successMessage = "Simulators Data removed successfully!"
+            let failureMessage = "Failed to remove Simulators Data"
             self.runShellCommand(launchPath: launchPath, arguments: arguments, successTitle: successTitle, successMessage: successMessage, failureMessage: failureMessage)
         case .clearCocoaPodsCache:
             let launchPath = "/bin/bash"


### PR DESCRIPTION
Implement removing simulator previews action and cleaning all simulators data action. Features not included in "Clean all" due to rare needed. Can be useful for users with small available disk space (like me)